### PR TITLE
Added new event and fallback to cookie storage

### DIFF
--- a/browsertab.js
+++ b/browsertab.js
@@ -42,7 +42,7 @@
 
     // Initialize primary state.
     if (!this.hidden() || !this._anyTabsPrimary()) {
-      this._makePrimary(true);
+      this._makePrimary();
     }
   }
 
@@ -203,12 +203,12 @@
       }
     };
 
-    p._makePrimary = function(initialize) {
+    p._makePrimary = function() {
       this._previousPrimary = this.store.getItem(this._storageNamespace);
       this.store.setItem(this._storageNamespace, this._id);
       this._currentPrimary = this._id;
-      // is a new primary being set, and is this not when BrowserTab is initializing
-      if (!initialize && this._primaryChanged()) {
+      // if a new primary being set after initialization
+      if (this._primaryChanged()) {
         for (var i=0; i < this.switchedPrimaryCallbacks.length; i++) {
           setTimeout(this.switchedPrimaryCallbacks[i], 0);
         }
@@ -235,11 +235,11 @@
       function syncPrimary() {
         self._blurred = self.hidden();
         if (!self.hidden()) {
-          self._makePrimary(false);
+          self._makePrimary();
         }
       }
 
-      this._makePrimary(true)
+      this._makePrimary()
       this._listenForVisibilityChange(syncPrimary);
     };
 
@@ -268,7 +268,7 @@
         self._previouslyBlurred = self._blurred;
         self._blurred = false;
         self._uncertain = false;
-        self._makePrimary(false); 
+        self._makePrimary(); 
         triggerBlurChangeCallbacks();
       }
 

--- a/browsertab.js
+++ b/browsertab.js
@@ -305,7 +305,7 @@
     };
 
     p._primaryChanged = function() {
-      return this._previousPrimary !== this._currentPrimary);
+      return this._previousPrimary !== this._currentPrimary;
     };
 
   })(BrowserTab.prototype);

--- a/browsertab.js
+++ b/browsertab.js
@@ -206,6 +206,7 @@
     p._makePrimary = function(initialize) {
       this._previousPrimary = this.store.getItem(this._storageNamespace);
       this.store.setItem(this._storageNamespace, this._id);
+      this._currentPrimary = this._id;
       // is a new primary being set, and is this not when BrowserTab is initializing
       if (!initialize && this._primaryChanged()) {
         for (var i=0; i < this.switchedPrimaryCallbacks.length; i++) {
@@ -304,7 +305,7 @@
     };
 
     p._primaryChanged = function() {
-      return this._previousPrimary !== this._id;
+      return this._previousPrimary !== this._currentPrimary);
     };
 
   })(BrowserTab.prototype);


### PR DESCRIPTION
Not sure if what I did is something you want in your master branch... feel free to take it or not :)

I added the "change:switchedBackAsPrimary" event which notifies you when a tab becomes a primary again. I basically needed a way to be notified only if a primary changed from one to another (excluding when BrowserTab is initialized). So I just hooked into the "makePrimary" method which seems to be the most reliable (although hacky) way to do this. I initially bound a callback to "listenForVisibilityChange" but found that there was a race condition when the visibilitychange event didn't exist: the "mousemove" event would be called twice before the callback would be fired, thus overwriting the first previousPrimary (which is how I detect whether a new primary is being a selected, or if the same primary is being selected again).

Also I now have localStorage fall back to cookie storage.
